### PR TITLE
Here's how I'll switch from the Flask development server to Gunicorn:

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ gunicorn --bind <DS_HOST>:<DS_PORT> deployment_service:app
 ```
 Replace `<DS_HOST>` and `<DS_PORT>` with your configured host and port.
 
+## Running with Gunicorn
+
+To run the deployment service using Gunicorn, a production-grade WSGI server, use the following command structure:
+
+```bash
+gunicorn --bind <host>:<port> deployment_service:app
+```
+
+Replace `<host>` with the desired host address (e.g., `0.0.0.0` to listen on all interfaces, or `127.0.0.1` for local access only) and `<port>` with the desired port number. The `deployment_service:app` part tells Gunicorn to use the `app` Flask object from the `deployment_service.py` file.
+
+For example, to run Gunicorn listening on port 5001 on all network interfaces:
+```bash
+gunicorn --bind 0.0.0.0:5001 deployment_service:app
+```
+
+Make sure you have Gunicorn installed (`pip install gunicorn`). It's recommended to use the host and port values that are consistent with your `DS_HOST` and `DS_PORT` configuration for the service.
+
 ## Service Deployment (Systemd)
 
 To run this deployment service as a background system service on Linux systems using systemd, follow these steps. Step 1 details the systemd unit configuration. Firewall configuration is detailed in Step 2 below.

--- a/deployment_service.py
+++ b/deployment_service.py
@@ -262,11 +262,3 @@ def service_restart_route():
         }), 500
     except Exception as e:
         return jsonify({"error": f"An unexpected error occurred while trying to restart the main application: {str(e)}"}), 500
-
-if __name__ == '__main__':
-    # Security Note: Flask's default development server is not for production.
-    # Use a production-grade WSGI server (e.g., Gunicorn, uWSGI) for deployment.
-    # This runs the deployment service.
-    # Ensure the main application (e.g., app.py) is running as a separate process.
-    # Use a production-grade WSGI server (e.g., Gunicorn, uWSGI).
-    app.run(host=app.config['DS_HOST'], port=app.config['DS_PORT'], debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 flask
+gunicorn


### PR DESCRIPTION
- First, I'll add Gunicorn to your `requirements.txt` file.
- Then, I'll remove the `app.run()` call from `deployment_service.py`.
- Finally, I'll update your `README.md` with instructions on how to run the application using Gunicorn.