### PR TITLE
I've added a self-restart capability to the deployment service.

### DIFF
--- a/deployment_service.py
+++ b/deployment_service.py
@@ -9,6 +9,7 @@
 # 3. Hardcoded defaults in this script
 
 import os
+import sys # Added import sys
 import json # Add this import
 from flask import Flask, jsonify, request, current_app, render_template # Ensure all are here
 import git_utils
@@ -251,3 +252,19 @@ def service_restart_route():
         }), 500
     except Exception as e:
         return jsonify({"error": f"An unexpected error occurred while trying to restart the main application: {str(e)}"}), 500
+
+@app.route('/deployment-service/self-restart', methods=['POST'])
+def self_restart_service_route():
+    # This command restarts THIS deployment service.
+    print("Attempting to self-restart deployment_service via sys.exit(1)...") # Basic logging
+    # Optionally, add a small delay if you want to ensure a response can be sent,
+    # though sys.exit might be abrupt. For a clean shutdown with Werkzeug:
+    # func = request.environ.get('werkzeug.server.shutdown')
+    # if func is None:
+    #     print('Not running with Werkzeug Server, using sys.exit().')
+    #     sys.exit(1) # Exit code 1 to indicate intentional restart
+    # func()
+    # For broader compatibility (e.g., with gunicorn), sys.exit() is more direct.
+    sys.exit(1) # Exit code 1 to indicate intentional restart by admin
+    # The following line is unlikely to be reached but included for completeness.
+    return jsonify({"message": "If you see this, shutdown failed. Service is attempting to exit."}), 200

--- a/templates/git_admin.html
+++ b/templates/git_admin.html
@@ -71,6 +71,7 @@
         <div class="section">
             <h2>Service Management</h2>
             <button onclick="restartService()" class="danger-button">Restart Service</button>
+            <button onclick="selfRestartService()" class="danger-button" style="margin-left: 10px;">Restart This Deployment Service</button>
         </div>
     </div>
 
@@ -163,6 +164,13 @@
                 return;
             }
             await handleGitAction('/service/restart', {}, 'Attempting to restart service...');
+        }
+
+        async function selfRestartService() {
+            if (!confirm('Are you sure you want to restart this deployment service? This will stop the admin interface temporarily.')) {
+                return;
+            }
+            await handleGitAction('/deployment-service/self-restart', {}, 'Attempting to restart this deployment service...');
         }
 
         async function handleGitAction(endpoint, body, loadingMessage) {


### PR DESCRIPTION
This change introduces a new button on the admin interface that allows you to restart the deployment service itself.

Key changes:
- Added a "Restart This Deployment Service" button to `templates/git_admin.html`.
- Implemented a new JavaScript function `selfRestartService()` in the HTML template, which prompts for confirmation and then calls a new backend endpoint.
- Created a new Flask route `/deployment-service/self-restart` in `deployment_service.py`.
- This endpoint calls `sys.exit(1)` to terminate the current service instance, relying on an external process manager (e.g., systemd, Docker, Kubernetes) to automatically restart it.
- Added `import sys` to `deployment_service.py`.

This functionality is distinct from the existing "Restart Service" button, which is intended for restarting a separate main application managed by this deployment service.