### PR TITLE
Fix: Implement flexible remote branch detection in checkout

### DIFF
--- a/git_utils.py
+++ b/git_utils.py
@@ -55,42 +55,98 @@ def checkout(repo_path, ref_name):
     it attempts to check it out as a local tracking branch.
     """
     logger.info(f"checkout: Received ref_name='{ref_name}' for repo_path='{repo_path}'")
-    safe_ref_name = shlex.quote(ref_name)
-    final_command_args = []
+    safe_ref_name = shlex.quote(ref_name) # This is the original ref, quoted, e.g., 'origin/feature/foo'
 
+    # --- New Flexible Remote Detection Logic ---
+    # Attempt to list remotes to handle cases like 'origin/feature-branch' directly
+    remote_list_stdout, remote_list_stderr, remote_list_retcode = run_git_command(['remote'], repo_path)
+    if remote_list_retcode == 0 and remote_list_stdout:
+        known_remotes = remote_list_stdout.split()
+        logger.info(f"checkout: Found known remotes: {known_remotes}")
+        for remote_name in known_remotes:
+            prefix = f"{remote_name}/"
+            if ref_name.startswith(prefix):
+                logger.info(f"checkout: Identified '{ref_name}' as prefixed by known remote '{remote_name}'.")
+                simple_branch_name = ref_name[len(prefix):]
+
+                if not simple_branch_name:
+                    logger.warning(f"checkout: Extracted empty simple_branch_name from '{ref_name}' with prefix '{prefix}'. Skipping this remote.")
+                    continue
+
+                safe_simple_branch_name = shlex.quote(simple_branch_name)
+                # The tracking ref for 'git checkout -b <local_name> <tracking_ref>' is the original, full ref_name.
+                # safe_ref_name is already shlex.quote(ref_name)
+
+                logger.info(f"checkout: Extracted simple_branch_name='{simple_branch_name}'. Checking for existing local branch.")
+
+                branch_check_cmd = ['branch', '--list', safe_simple_branch_name]
+                logger.info(f"checkout: Checking for existing local branch '{simple_branch_name}' with command: git {' '.join(branch_check_cmd)}")
+                stdout_check, stderr_check, retcode_check = run_git_command(branch_check_cmd, repo_path)
+                logger.info(f"checkout: 'git branch --list' stdout: '{stdout_check}', stderr: '{stderr_check}', retcode: {retcode_check}")
+
+                final_checkout_cmd_args = []
+                if retcode_check == 0: # 'git branch --list' command executed successfully
+                    if not stdout_check.strip(): # Local branch does NOT exist
+                        logger.info(f"checkout: Local branch '{simple_branch_name}' not found. Preparing to create new tracking branch from '{ref_name}'.")
+                        final_checkout_cmd_args = ['checkout', '-b', safe_simple_branch_name, safe_ref_name]
+                    else: # Local branch DOES exist
+                        logger.info(f"checkout: Local branch '{simple_branch_name}' exists. Preparing to checkout this local branch.")
+                        final_checkout_cmd_args = ['checkout', safe_simple_branch_name]
+                else: # 'git branch --list' command failed
+                    logger.warning(f"checkout: 'git branch --list {safe_simple_branch_name}' failed (retcode: {retcode_check}). Falling back to checkout original ref '{ref_name}'.")
+                    final_checkout_cmd_args = ['checkout', safe_ref_name]
+
+                logger.info(f"checkout: Executing command (from new logic): git {' '.join(final_checkout_cmd_args)}")
+                stdout, stderr, retcode = run_git_command(final_checkout_cmd_args, repo_path)
+                logger.info(f"checkout: Command (from new logic) stdout: '{stdout}', stderr: '{stderr}', retcode: {retcode}")
+                return stdout, stderr, retcode # Crucial: return after handling
+    else:
+        logger.warning(f"checkout: Could not retrieve remote names (retcode: {remote_list_retcode}, stderr: {remote_list_stderr}). Proceeding with 'remotes/' prefix check or direct checkout.")
+    # --- End of New Flexible Remote Detection Logic ---
+
+    # --- Fallback to existing 'remotes/' prefix logic if new logic did not handle and return ---
+    # This block is largely for refs that literally start with "remotes/"
     if ref_name.startswith('remotes/'):
-        logger.info(f"checkout: '{ref_name}' appears to be a remote branch.")
+        logger.info(f"checkout: (Fallback) '{ref_name}' appears to be a 'remotes/' prefixed branch.")
         parts = ref_name.split('/')
-        if len(parts) > 2: # Minimum remotes/<remote_name>/<branch_name>
-            simple_branch_name = parts[-1]
-            safe_simple_branch_name = shlex.quote(simple_branch_name)
-            logger.info(f"checkout: Extracted simple_branch_name='{simple_branch_name}' from remote ref.")
+        # Example: remotes/origin/feature. parts[0]=remotes, parts[1]=origin, parts[2]=feature
+        # We need at least 3 parts for a simple_branch_name (remotes/<remote_name>/<branch_name>)
+        if len(parts) > 2:
+            simple_branch_name_from_remotes_prefix = parts[-1] # Last part is the branch name
+            safe_simple_branch_name_from_remotes_prefix = shlex.quote(simple_branch_name_from_remotes_prefix)
+            logger.info(f"checkout: (Fallback) Extracted simple_branch_name='{simple_branch_name_from_remotes_prefix}' from 'remotes/' ref.")
 
-            branch_check_cmd = ['branch', '--list', safe_simple_branch_name]
-            logger.info(f"checkout: Checking for existing local branch '{simple_branch_name}' with command: git {' '.join(branch_check_cmd)}")
+            branch_check_cmd = ['branch', '--list', safe_simple_branch_name_from_remotes_prefix]
+            logger.info(f"checkout: (Fallback) Checking for existing local branch '{simple_branch_name_from_remotes_prefix}' with command: git {' '.join(branch_check_cmd)}")
             stdout_check, stderr_check, retcode_check = run_git_command(branch_check_cmd, repo_path)
-            logger.info(f"checkout: 'git branch --list' stdout: '{stdout_check}', stderr: '{stderr_check}', retcode: {retcode_check}")
+            logger.info(f"checkout: (Fallback) 'git branch --list' stdout: '{stdout_check}', stderr: '{stderr_check}', retcode: {retcode_check}")
 
+            final_checkout_cmd_args = []
             if retcode_check == 0: # 'git branch --list' command executed successfully
                 if not stdout_check.strip():
-                    logger.info(f"checkout: Local branch '{simple_branch_name}' not found. Preparing to create new tracking branch.")
-                    final_command_args = ['checkout', '-b', safe_simple_branch_name, safe_ref_name]
+                    logger.info(f"checkout: (Fallback) Local branch '{simple_branch_name_from_remotes_prefix}' not found. Preparing to create new tracking branch from '{ref_name}'.")
+                    final_checkout_cmd_args = ['checkout', '-b', safe_simple_branch_name_from_remotes_prefix, safe_ref_name]
                 else:
-                    logger.info(f"checkout: Local branch '{simple_branch_name}' exists. Preparing to checkout local branch.")
-                    final_command_args = ['checkout', safe_simple_branch_name]
+                    logger.info(f"checkout: (Fallback) Local branch '{simple_branch_name_from_remotes_prefix}' exists. Preparing to checkout this local branch.")
+                    final_checkout_cmd_args = ['checkout', safe_simple_branch_name_from_remotes_prefix]
             else:
-                logger.warning(f"checkout: 'git branch --list {safe_simple_branch_name}' failed (retcode: {retcode_check}). Falling back to checkout original ref_name.")
-                final_command_args = ['checkout', safe_ref_name]
-        else:
-            logger.warning(f"checkout: Remote branch name '{ref_name}' seems malformed. Falling back to direct checkout.")
-            final_command_args = ['checkout', safe_ref_name]
-    else:
-        logger.info(f"checkout: '{ref_name}' is not a remote branch. Proceeding with normal checkout.")
-        final_command_args = ['checkout', safe_ref_name]
+                logger.warning(f"checkout: (Fallback) 'git branch --list {safe_simple_branch_name_from_remotes_prefix}' failed (retcode: {retcode_check}). Falling back to checkout original ref '{ref_name}'.")
+                final_checkout_cmd_args = ['checkout', safe_ref_name]
 
-    logger.info(f"checkout: Executing final checkout command: git {' '.join(final_command_args)}")
-    stdout, stderr, retcode = run_git_command(final_command_args, repo_path)
-    logger.info(f"checkout: Final checkout stdout: '{stdout}', stderr: '{stderr}', retcode: {retcode}")
+            logger.info(f"checkout: Executing command (from fallback 'remotes/' logic): git {' '.join(final_checkout_cmd_args)}")
+            stdout, stderr, retcode = run_git_command(final_checkout_cmd_args, repo_path)
+            logger.info(f"checkout: Command (from fallback 'remotes/' logic) stdout: '{stdout}', stderr: '{stderr}', retcode: {retcode}")
+            return stdout, stderr, retcode
+        else: # Malformed 'remotes/' ref like 'remotes/origin'
+            logger.warning(f"checkout: (Fallback) 'remotes/' prefixed ref_name '{ref_name}' seems malformed. Falling back to direct checkout of '{ref_name}'.")
+            # Fall through to the final direct checkout
+
+    # --- Final direct checkout if no other logic handled it ---
+    logger.info(f"checkout: No specific remote branch logic matched or fell through. Executing direct checkout for '{ref_name}'.")
+    final_checkout_cmd_args = ['checkout', safe_ref_name]
+    logger.info(f"checkout: Executing command (direct): git {' '.join(final_checkout_cmd_args)}")
+    stdout, stderr, retcode = run_git_command(final_checkout_cmd_args, repo_path)
+    logger.info(f"checkout: Command (direct) stdout: '{stdout}', stderr: '{stderr}', retcode: {retcode}")
     return stdout, stderr, retcode
 
 def pull(repo_path):


### PR DESCRIPTION
This commit resolves an issue where the `checkout` logic failed to correctly identify remote branches specified without the `remotes/` prefix (e.g., `origin/my-feature` instead of `remotes/origin/my-feature`). This previously led to the repository entering a detached HEAD state when such a reference was checked out, causing subsequent `git pull` operations to fail.

The `git_utils.checkout()` function has been enhanced:
- It now first attempts to detect remote branches by fetching the list of known remotes (via `git remote`) and checking if the input reference starts with `<known_remote_name>/`.
- If such a pattern is matched (e.g., `origin/my-feature`), it extracts the simple branch name (`my-feature`) and proceeds to either:
    - Create a new local tracking branch (`git checkout -b my-feature origin/my-feature`) if no local branch `my-feature` exists.
    - Check out the existing local branch (`git checkout my-feature`) if it already exists.
- If this new dynamic detection doesn't match, the function falls back to the previous logic of checking for the `remotes/` prefix, and finally to a direct checkout attempt.
- Logging throughout this process has been maintained and improved for clarity.

Test cases in `test_deployment_service.py` have been updated:
- Existing tests for `remotes/` prefixed checkouts were reviewed and confirmed valid.
- New test cases were added to specifically verify the correct handling of `origin/branch-name` style references for both creating new local tracking branches and activating existing local branches.
- A test helper method `_assert_checkout_success` was introduced to streamline checkout assertions.

This comprehensive fix should now correctly handle various ways of specifying remote branches, ensuring the appropriate local tracking branch is created or activated, thus preventing the detached HEAD issue.