### PR TITLE
feat: Add self-restart capability to deployment service

### DIFF
--- a/templates/git_admin.html
+++ b/templates/git_admin.html
@@ -71,6 +71,7 @@
         <div class="section">
             <h2>Service Management</h2>
             <button onclick="restartService()" class="danger-button">Restart Service</button>
+            <button id="restartDeploymentServiceButton" onclick="restartDeploymentService()" class="danger-button">Restart Deployment Service</button>
         </div>
     </div>
 
@@ -163,6 +164,13 @@
                 return;
             }
             await handleGitAction('/service/restart', {}, 'Attempting to restart service...');
+        }
+
+        async function restartDeploymentService() {
+            if (!confirm('Are you sure you want to restart the deployment service itself? This will temporarily interrupt its operations.')) {
+                return;
+            }
+            await handleGitAction('/deployment-service/restart-self', {}, 'Attempting to restart deployment service...');
         }
 
         async function handleGitAction(endpoint, body, loadingMessage) {


### PR DESCRIPTION
This commit introduces a new feature allowing the deployment service to restart itself.

Changes:
- Added a "Restart Deployment Service" button to the admin UI (`templates/git_admin.html`).
- Implemented a new JavaScript function `restartDeploymentService()` that prompts for confirmation and calls a new backend endpoint.
- Added a new POST endpoint `/deployment-service/restart-self` in `deployment_service.py`.
- This endpoint logs an intent to restart and then calls `sys.exit(0)`. The actual restart of the service relies on an external process manager (e.g., systemd, supervisor, Docker, or a script wrapper) monitoring the process and restarting it upon exit.

The existing "Restart Service" button and its backend `/service/restart` endpoint are for restarting a separate main application managed by this deployment service, and their functionality remains unchanged.