### PR TITLE
Fix: Resolve relative import error in deployment_service

### DIFF
--- a/deployment_service.py
+++ b/deployment_service.py
@@ -13,8 +13,8 @@ import json # Add this import
 import sys # Import sys module
 import signal # Import signal module
 from flask import Flask, jsonify, request, current_app, render_template
-from . import git_utils # Assuming git_utils is in the same package
-from .git_utils import get_stale_local_branches, delete_local_branch # Specific imports
+import git_utils # Assuming git_utils is in the same package
+from git_utils import get_stale_local_branches, delete_local_branch # Specific imports
 import shlex
 import subprocess
 import logging


### PR DESCRIPTION
I've changed the relative imports for git_utils in deployment_service.py to absolute imports.

This addresses the error "ImportError: attempted relative import with no known parent package" which occurs when deployment_service.py is run as the top-level script.

The changes are:
- `from . import git_utils` changed to `import git_utils`
- `from .git_utils import ...` changed to `from git_utils import ...`

This allows the script to correctly locate git_utils.py in the same directory and makes the import behavior consistent with how tests import from deployment_service.