### PR TITLE
feat: Automatically restart service after git pull or checkout

### DIFF
--- a/templates/git_admin.html
+++ b/templates/git_admin.html
@@ -205,7 +205,17 @@
                 responseData = await response.json();
 
                 if (response.ok) {
-                    updateStatus(responseData.message || 'Action successful.', 'success');
+                    let finalMessage = responseData.message || 'Action successful.';
+                    // Check for restart_status in pull or checkout operations
+                    if ((endpoint === '/git/pull' || endpoint === '/git/checkout') && responseData.restart_status) {
+                        if (responseData.restart_status.message) {
+                            finalMessage += ` ${responseData.restart_status.message}`;
+                        }
+                        // If restart failed or had an issue, the message from restart_status should reflect that.
+                        // The main status of the git operation is still 'success' here.
+                    }
+                    updateStatus(finalMessage, 'success');
+
                     if (responseData.stdout) console.log('STDOUT:', responseData.stdout);
                     if (responseData.stderr) console.warn('STDERR:', responseData.stderr);
                      // Specific refresh logic


### PR DESCRIPTION
This commit introduces functionality to automatically restart the main application service after a successful 'git pull' or 'git checkout' operation performed via the deployment service.

Changes:
- Modified `deployment_service.py`:
    - Added a helper function `_trigger_service_restart` to encapsulate the restart logic.
    - Integrated this helper into the `/git/pull` and `/git/checkout` endpoints to trigger a restart upon successful completion of these git operations.
    - The JSON responses for these endpoints now include a `restart_status` field detailing the outcome of the restart attempt.
- Updated `test_deployment_service.py`:
    - Added comprehensive tests for the new automatic restart feature.
    - Tests cover scenarios including successful git operations triggering restarts, handling of unconfigured restart commands, and ensuring no restart is attempted on failed git operations.
- Modified `templates/git_admin.html`:
    - Updated the `handleGitAction` JavaScript function to display information about the service restart attempt to you in the status message, appending it to the git operation's success message.